### PR TITLE
Also make it easy to make non-ontology models

### DIFF
--- a/plugins/net.bioclipse.rdf.tests/src/net/bioclipse/rdf/tests/AbstractRDFManagerPluginTest.java
+++ b/plugins/net.bioclipse.rdf.tests/src/net/bioclipse/rdf/tests/AbstractRDFManagerPluginTest.java
@@ -36,9 +36,16 @@ public abstract class AbstractRDFManagerPluginTest {
         IRDFStore store = rdf.createStore("/Virtual/test.store");
         Assert.assertNotNull(store);
     }
-    
+
     @Test public void testCreateInMemoryStore() {
         IRDFStore store = rdf.createInMemoryStore();
+        Assert.assertNotNull(store);
+    }
+
+    @Test public void testCreateInMemoryStore2() {
+        IRDFStore store = rdf.createInMemoryStore(false);
+        Assert.assertNotNull(store);
+        store = rdf.createInMemoryStore(true);
         Assert.assertNotNull(store);
     }
 

--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
@@ -44,6 +44,14 @@ public interface IRDFManager extends IBioclipseManager {
 
     @Recorded
     @PublishedMethod(
+    	params="boolean ontologyModel",
+        methodSummary = "Creates a new in-memory store."
+    )
+    @TestMethods("testCreateInMemoryStore2")
+    public IRDFStore createInMemoryStore(boolean ontologyModel);
+
+    @Recorded
+    @PublishedMethod(
         params = "String tripleStoreDirectoryPath",
         methodSummary = "Creates a new on-disk store, " +
             "(using the Jena TDB package, which stores on disk as a " +

--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/JenaModel.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/JenaModel.java
@@ -18,11 +18,18 @@ public class JenaModel implements IJenaStore {
     private Model model;
     
     public JenaModel() {
+    	this(true);
+    }
+
+    public JenaModel(boolean ontologyModel) {
     	org.apache.jena.riot.adapters.JenaReadersWriters.RDFReaderRIOT_TTL.class.getName();
     	org.apache.jena.riot.adapters.JenaReadersWriters.RDFReaderRIOT_NT.class.getName();
     	org.apache.jena.riot.adapters.JenaReadersWriters.RDFReaderRIOT_RDFJSON.class.getName();
     	org.apache.jena.riot.adapters.JenaReadersWriters.RDFReaderRIOT_RDFXML.class.getName();
-        model = ModelFactory.createOntologyModel();
+    	if (ontologyModel)
+    		model = ModelFactory.createOntologyModel();
+    	else
+    		model = ModelFactory.createDefaultModel();
     }
 
     public JenaModel( Model jenaTypeModel ) {

--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/RDFManager.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/RDFManager.java
@@ -216,6 +216,10 @@ public class RDFManager implements IBioclipseManager {
         return new JenaModel();
     }
 
+    public IRDFStore createInMemoryStore(boolean ontologyModel) {
+        return new JenaModel(ontologyModel);
+    }
+
     public IRDFStore createStore(String tripleStoreDirectoryPath) {
     	return new TDBModel(tripleStoreDirectoryPath);
     }


### PR DESCRIPTION
The default being an ontology model makes querying much slower. Now you can create a simple model via the API too.