### PR TITLE
RDF patches: more functionality exposed

### DIFF
--- a/plugins/net.bioclipse.owl/src/net/bioclipse/owl/business/IOWLManager.java
+++ b/plugins/net.bioclipse.owl/src/net/bioclipse/owl/business/IOWLManager.java
@@ -11,6 +11,7 @@
 package net.bioclipse.owl.business;
 
 import java.io.IOException;
+import java.util.List;
 
 import net.bioclipse.core.PublishedClass;
 import net.bioclipse.core.PublishedMethod;
@@ -26,23 +27,44 @@ public interface IOWLManager extends IBioclipseManager {
 
     @PublishedMethod(
          params = "IRDFStore store",
-         methodSummary = "Returns a list of all OWL classes."
+         methodSummary = "Returns a StringMatrix with all OWL classes."
     )
     public StringMatrix listClasses(IRDFStore store)
         throws IOException, BioclipseException, CoreException;
     
     @PublishedMethod(
         params = "IRDFStore store",
-        methodSummary = "Returns a list of all OWL object properties."
+        methodSummary = "Returns a StringMatrix with all OWL object properties."
     )
     public StringMatrix listObjectProperties(IRDFStore store)
     throws IOException, BioclipseException, CoreException;
        
     @PublishedMethod(
         params = "IRDFStore store",
-        methodSummary = "Returns a list of all OWL data type properties."
+        methodSummary = "Returns a StringMatrix with OWL data type properties."
     )
     public StringMatrix listDatatypeProperties(IRDFStore store)
     throws IOException, BioclipseException, CoreException;
        
+    @PublishedMethod(
+        params = "IRDFStore store",
+        methodSummary = "Returns a list of all OWL classes."
+    )
+    public List<String> getClasses(IRDFStore store)
+    	throws IOException, BioclipseException, CoreException;
+
+    @PublishedMethod(
+    	params = "IRDFStore store",
+    	methodSummary = "Returns a list of all OWL object properties."
+    )
+    public List<String> getObjectProperties(IRDFStore store)
+    	throws IOException, BioclipseException, CoreException;
+
+    @PublishedMethod(
+    	params = "IRDFStore store",
+    	methodSummary = "Returns a list of all OWL data type properties."
+    )
+    public List<String> getDatatypeProperties(IRDFStore store)
+    	throws IOException, BioclipseException, CoreException;
+          
 }

--- a/plugins/net.bioclipse.owl/src/net/bioclipse/owl/business/OWLManager.java
+++ b/plugins/net.bioclipse.owl/src/net/bioclipse/owl/business/OWLManager.java
@@ -19,18 +19,22 @@
 package net.bioclipse.owl.business;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 import net.bioclipse.core.business.BioclipseException;
 import net.bioclipse.core.domain.StringMatrix;
 import net.bioclipse.managers.business.IBioclipseManager;
 import net.bioclipse.pellet.business.PelletManager;
 import net.bioclipse.rdf.business.IRDFStore;
+import net.bioclipse.rdf.business.RDFManager;
 
 import org.eclipse.core.runtime.CoreException;
 
 public class OWLManager implements IBioclipseManager {
 
-    PelletManager rdf = new PelletManager(); 
+    PelletManager pellet = new PelletManager();
+    RDFManager rdf = new RDFManager();
     
     public String getManagerName() {
         return "owl";
@@ -38,21 +42,48 @@ public class OWLManager implements IBioclipseManager {
 
     public StringMatrix listClasses(IRDFStore store)
         throws IOException, BioclipseException, CoreException {
-        return rdf.isRDFType(
+        return pellet.isRDFType(
             store, "http://www.w3.org/2002/07/owl#Class"
         );
     }
-    
+
+    public List<String> getClasses(IRDFStore store)
+        throws IOException, BioclipseException, CoreException {
+    	if (store == null) return Collections.emptyList();
+    	if (rdf.size(store) < 1) return Collections.emptyList();
+    	return pellet.getRDFType(
+            store, "http://www.w3.org/2002/07/owl#Class"
+        );
+    }
+
     public StringMatrix listObjectProperties(IRDFStore store)
     throws IOException, BioclipseException, CoreException {
-    	return rdf.isRDFType(
+    	return pellet.isRDFType(
     		store, "http://www.w3.org/2002/07/owl#ObjectProperty"
     	);
     }
-    
+
+    public List<String> getObjectProperties(IRDFStore store)
+    throws IOException, BioclipseException, CoreException {
+    	if (store == null) return Collections.emptyList();
+    	if (rdf.size(store) < 1) return Collections.emptyList();
+    	return pellet.getRDFType(
+    		store, "http://www.w3.org/2002/07/owl#ObjectProperty"
+    	);
+    }
+
     public StringMatrix listDatatypeProperties(IRDFStore store)
     throws IOException, BioclipseException, CoreException {
-    	return rdf.isRDFType(
+    	return pellet.isRDFType(
+    		store, "http://www.w3.org/2002/07/owl#DatatypeProperty"
+    	);
+    }
+
+    public List<String> getDatatypeProperties(IRDFStore store)
+    throws IOException, BioclipseException, CoreException {
+    	if (store == null) return Collections.emptyList();
+    	if (rdf.size(store) < 1) return Collections.emptyList();
+    	return pellet.getRDFType(
     		store, "http://www.w3.org/2002/07/owl#DatatypeProperty"
     	);
     }

--- a/plugins/net.bioclipse.owlapi.business/src/net/bioclipse/owlapi/business/IOWLAPIManager.java
+++ b/plugins/net.bioclipse.owlapi.business/src/net/bioclipse/owlapi/business/IOWLAPIManager.java
@@ -75,6 +75,22 @@ public interface IOWLAPIManager extends IBioclipseManager {
 	@Recorded
     @PublishedMethod(
         params = "OWLOntology ontology",
+        methodSummary = "Returns the OWL properties as a List of String's."
+    )
+    public List<String> getProperties(OWLOntology ontology)
+        throws IOException, BioclipseException, CoreException;
+
+	@Recorded
+    @PublishedMethod(
+        params = "OWLOntology ontology",
+        methodSummary = "Returns the (non-asserted) OWL classes as a List of String's."
+    )
+    public List<String> getClasses(OWLOntology ontology)
+        throws IOException, BioclipseException, CoreException;
+
+	@Recorded
+    @PublishedMethod(
+        params = "OWLOntology ontology",
         methodSummary = "Shows the OWL properties."
     )
     public String showProperties(OWLOntology ontology)

--- a/plugins/net.bioclipse.owlapi.business/src/net/bioclipse/owlapi/business/OWLAPIManager.java
+++ b/plugins/net.bioclipse.owlapi.business/src/net/bioclipse/owlapi/business/OWLAPIManager.java
@@ -136,6 +136,28 @@ public class OWLAPIManager implements IBioclipseManager {
 		return list.toString();
 	}
 
+	public List<String> getClasses(OWLOntology ontology, IProgressMonitor monitor)
+	throws IOException, BioclipseException, CoreException {
+		if (monitor == null) monitor = new NullProgressMonitor();
+
+		List<String> list = new ArrayList<String>();
+		for (OWLClass cls : ontology.getClassesInSignature()) {
+			list.add(cls.getIRI().toString());
+		}
+		return list;
+	}
+
+	public List<String> getProperties(OWLOntology ontology, IProgressMonitor monitor)
+	throws IOException, BioclipseException, CoreException {
+		if (monitor == null) monitor = new NullProgressMonitor();
+
+		List<String> list = new ArrayList<String>();
+		for (OWLAnnotationProperty prop : ontology.getAnnotationPropertiesInSignature()) {
+			list.add(prop.getIRI().toString());
+		}
+		return list;
+	}
+
 	public List<OWLOntology> getImportedOntologies(OWLOntology ontology, IProgressMonitor monitor)
 	throws IOException, BioclipseException, CoreException {
 		if (monitor == null) monitor = new NullProgressMonitor();

--- a/plugins/net.bioclipse.pellet/src/net/bioclipse/pellet/business/PelletManager.java
+++ b/plugins/net.bioclipse.pellet/src/net/bioclipse/pellet/business/PelletManager.java
@@ -20,6 +20,7 @@ package net.bioclipse.pellet.business;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 
 import net.bioclipse.core.business.BioclipseException;
 import net.bioclipse.core.domain.StringMatrix;
@@ -163,6 +164,17 @@ public class PelletManager implements IBioclipseManager {
     			"  ?o rdf:type <" + type + ">." +
     			"}"
     	);
+    }
+
+    public List<String> getRDFType(IRDFStore store, String type)
+        throws IOException, BioclipseException, CoreException {
+    	return reason(
+        	store,
+        	"PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> " +
+        	"SELECT ?o WHERE { "+
+        	"  ?o rdf:type <" + type + ">." +
+        	"}"
+        ).getColumn("o");
     }
 
     public StringMatrix allAbout(IRDFStore store, String identifier)

--- a/plugins/net.bioclipse.rdf.tests/src/net/bioclipse/rdf/tests/AbstractRDFManagerPluginTest.java
+++ b/plugins/net.bioclipse.rdf.tests/src/net/bioclipse/rdf/tests/AbstractRDFManagerPluginTest.java
@@ -36,9 +36,16 @@ public abstract class AbstractRDFManagerPluginTest {
         IRDFStore store = rdf.createStore("/Virtual/test.store");
         Assert.assertNotNull(store);
     }
-    
+
     @Test public void testCreateInMemoryStore() {
         IRDFStore store = rdf.createInMemoryStore();
+        Assert.assertNotNull(store);
+    }
+
+    @Test public void testCreateInMemoryStore2() {
+        IRDFStore store = rdf.createInMemoryStore(false);
+        Assert.assertNotNull(store);
+        store = rdf.createInMemoryStore(true);
         Assert.assertNotNull(store);
     }
 

--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
@@ -389,4 +389,13 @@ public interface IRDFManager extends IBioclipseManager {
     )
     public IRDFStore copy(IRDFStore store, String predicate, String newPredicate)
     throws IOException, BioclipseException, CoreException;
+
+    @Recorded
+    @PublishedMethod(
+        params = "IRDFStore store, String predicate, String newPredicate",
+        methodSummary = "Renames all triples with a particular predicate to new predicates with the "
+        		+ "same resource or same literal value."
+    )
+    public IRDFStore rename(IRDFStore store, String predicate, String newPredicate)
+    throws IOException, BioclipseException, CoreException;
 }

--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
@@ -380,4 +380,13 @@ public interface IRDFManager extends IBioclipseManager {
     )
     public IRDFStore extract(IRDFStore store, String iri)
     throws IOException, BioclipseException, CoreException;
+
+    @Recorded
+    @PublishedMethod(
+        params = "IRDFStore store, String predicate, String newPredicate",
+        methodSummary = "Copies all triples with a particular predicate to new predicates with the "
+        		+ "same resource or same literal value."
+    )
+    public IRDFStore copy(IRDFStore store, String predicate, String newPredicate)
+    throws IOException, BioclipseException, CoreException;
 }

--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
@@ -372,4 +372,12 @@ public interface IRDFManager extends IBioclipseManager {
     )
     public List<String> shortestPath(IRDFStore store, String firstNode, String secondNode, String predicate)
     throws IOException, BioclipseException, CoreException;
+
+    @Recorded
+    @PublishedMethod(
+        params = "IRDFStore store, String iri",
+        methodSummary = "Extract all triples from and to the given class IRI."
+    )
+    public IRDFStore extract(IRDFStore store, String iri)
+    throws IOException, BioclipseException, CoreException;
 }

--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
@@ -44,6 +44,14 @@ public interface IRDFManager extends IBioclipseManager {
 
     @Recorded
     @PublishedMethod(
+    	params="boolean ontologyModel",
+        methodSummary = "Creates a new in-memory store."
+    )
+    @TestMethods("testCreateInMemoryStore2")
+    public IRDFStore createInMemoryStore(boolean ontologyModel);
+
+    @Recorded
+    @PublishedMethod(
         params = "String tripleStoreDirectoryPath",
         methodSummary = "Creates a new on-disk store, " +
             "(using the Jena TDB package, which stores on disk as a " +

--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/JenaModel.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/JenaModel.java
@@ -18,11 +18,18 @@ public class JenaModel implements IJenaStore {
     private Model model;
     
     public JenaModel() {
+    	this(true);
+    }
+
+    public JenaModel(boolean ontologyModel) {
     	org.apache.jena.riot.adapters.JenaReadersWriters.RDFReaderRIOT_TTL.class.getName();
     	org.apache.jena.riot.adapters.JenaReadersWriters.RDFReaderRIOT_NT.class.getName();
     	org.apache.jena.riot.adapters.JenaReadersWriters.RDFReaderRIOT_RDFJSON.class.getName();
     	org.apache.jena.riot.adapters.JenaReadersWriters.RDFReaderRIOT_RDFXML.class.getName();
-        model = ModelFactory.createOntologyModel();
+    	if (ontologyModel)
+    		model = ModelFactory.createOntologyModel();
+    	else
+    		model = ModelFactory.createDefaultModel();
     }
 
     public JenaModel( Model jenaTypeModel ) {

--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/RDFManager.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/RDFManager.java
@@ -216,6 +216,10 @@ public class RDFManager implements IBioclipseManager {
         return new JenaModel();
     }
 
+    public IRDFStore createInMemoryStore(boolean ontologyModel) {
+        return new JenaModel(ontologyModel);
+    }
+
     public IRDFStore createStore(String tripleStoreDirectoryPath) {
     	return new TDBModel(tripleStoreDirectoryPath);
     }

--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/RDFManager.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/RDFManager.java
@@ -845,6 +845,17 @@ public class RDFManager implements IBioclipseManager {
 
     public IRDFStore copy(IRDFStore store, String predicate, String newPredicate, IProgressMonitor monitor)
     throws IOException, BioclipseException, CoreException {
+    	return rename(store, predicate, newPredicate, false, monitor);
+    }
+
+    public IRDFStore rename(IRDFStore store, String predicate, String newPredicate, IProgressMonitor monitor)
+    throws IOException, BioclipseException, CoreException {
+    	return rename(store, predicate, newPredicate, true, monitor);
+    }
+
+    private IRDFStore rename(IRDFStore store, String predicate, String newPredicate,
+    	boolean replace, IProgressMonitor monitor)
+    throws IOException, BioclipseException, CoreException {
     	if (!(store instanceof IJenaStore))
             throw new RuntimeException(
                 "Can only handle IJenaStore's for now."
@@ -860,16 +871,20 @@ public class RDFManager implements IBioclipseManager {
         Selector selector = new SimpleSelector(
         	(Resource)null, model.createProperty(predicate), (RDFNode)null
         );
+        List<Statement> statementsToRemove = new ArrayList<Statement>();
         StmtIterator statements = model.listStatements(selector);
         while (statements.hasNext()) {
             Statement statement = statements.nextStatement();
             Resource subNode = statement.getSubject();
             RDFNode object = statement.getObject();
             newTriples.add(subNode, newProperty, object);
+            statementsToRemove.add(statement);
         }
         statements.close();
+        for (Statement statement : statementsToRemove) model.remove(statement);
         model.add(newTriples);
 
         return store;
     }
+
 }


### PR DESCRIPTION
- easier to make non-ontological models (thus not automatically using OWL reasoning)
- getOfType() using OWL reasoning (via Pellet)
- getting classes and properties for ontologies
- rename and/or copy a triple, replacing the predicate