### PR TITLE
Don't export the package with the Activator, which confuses Bioclipse

### DIFF
--- a/plugins/net.bioclipse.rdf.core/META-INF/MANIFEST.MF
+++ b/plugins/net.bioclipse.rdf.core/META-INF/MANIFEST.MF
@@ -7,8 +7,7 @@ Bundle-Activator: net.bioclipse.rdf.Activator
 Bundle-Vendor: The Bioclipse Team
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.log4j
-Export-Package: net.bioclipse.rdf,
- net.bioclipse.rdf.business
+Export-Package: net.bioclipse.rdf.business
 Require-Bundle: net.bioclipse.core,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,


### PR DESCRIPTION
Arvid, I made a mistake in the export of packages in the net.bioclipse.rdf.core plugin, which I missed before sending out the pull request for the plugin... this commit removes the exported package.