### PR TITLE
Removed non-existing plugins

### DIFF
--- a/features/net.bioclipse.rdf_feature/feature.xml
+++ b/features/net.bioclipse.rdf_feature/feature.xml
@@ -40,9 +40,6 @@ Jena is built on top of other sub-systems which we gratefully acknowledge: detai
    </license>
 
    <requires>
-      <import plugin="com.hp.hpl.jena" version="2.5.6" match="greaterOrEqual"/>
-      <import plugin="com.hp.hpl.jena.arq" version="2.8.2" match="greaterOrEqual"/>
-      <import plugin="com.hp.hpl.jena.tdb" version="0.8.4" match="greaterOrEqual"/>
       <import plugin="log4j.over.slf4j"/>
       <import plugin="javax.xml" version="1.3.4" match="compatible"/>
       <import plugin="net.bioclipse.core"/>
@@ -56,13 +53,14 @@ Jena is built on top of other sub-systems which we gratefully acknowledge: detai
       <import plugin="org.apache.xml.resolver" version="1.2.0" match="compatible"/>
       <import plugin="org.apache.xml.serializer" version="2.7.1" match="compatible"/>
       <import feature="net.bioclipse.statistics_feature" version="2.5.0" match="greaterOrEqual"/>
+      <import plugin="com.hp.hpl.jena" version="2.5.6" match="greaterOrEqual"/>
    </requires>
 
    <plugin
          id="net.bioclipse.rdf.core"
          download-size="0"
-         install-size="0" 
-         version="0.0.0" 
+         install-size="0"
+         version="0.0.0"
          unpack="false"/>
 
    <plugin
@@ -74,13 +72,6 @@ Jena is built on top of other sub-systems which we gratefully acknowledge: detai
 
    <plugin
          id="com.hp.hpl.jena"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.hp.hpl.jena.arq"
          download-size="0"
          install-size="0"
          version="0.0.0"
@@ -109,20 +100,6 @@ Jena is built on top of other sub-systems which we gratefully acknowledge: detai
 
    <plugin
          id="javax.xml"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.hp.hpl.jena.tdb"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="net.bioclipse.owlapi.business"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
[16/05/16 14:54] <egonw> Gpox: if I look at bioclipse.rdf RC branch (also develop), the RDF feature has the following plugins:
[16/05/16 14:54] <egonw> com.hp.hpl.jena, com.hp.hpl.jena.arq, and com.hp.hpl.jena.tdb
[16/05/16 14:55] <egonw> but a while ago, the jars of the TDB and ARQ were integrated into the first plugin
[16/05/16 14:55] <egonw> and the .arq and .tdb plugins were removed...
[16/05/16 14:55] <egonw> but they are still in the feature
[16/05/16 14:55] <egonw> can you confirm this problem?
[16/05/16 14:55] <egonw> or shall I just make a PR for you to confirm?

Arvid, this should probably also apply to the RC branch.
