### PR TITLE
Added a helper method to process XML results returned by a SPARQL endpoint

### DIFF
--- a/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
+++ b/plugins/net.bioclipse.rdf/src/net/bioclipse/rdf/business/IRDFManager.java
@@ -264,6 +264,15 @@ public interface IRDFManager extends IBioclipseManager {
 
     @Recorded
     @PublishedMethod(
+        params = "String queryResults, String originalQuery",
+        methodSummary = "Parses the XML-formatted SPARQL end point results into an IStringMatrix. "
+        		+ "The originalQuery is used to determine prefixes."
+    )
+    public IStringMatrix processSPARQLXML(byte[] queryResults, String originalQuery)
+        throws BioclipseException;
+
+    @Recorded
+    @PublishedMethod(
         params = "String url, String SPARQL",
         methodSummary = "Queries a remote SPARQL endpoint and returns RDF/XML. " +
         		        "Assumes that the query is creating an RDF graph with the " +


### PR DESCRIPTION
Method to parse XML returned by SPARQL end points, with the option to parse a Jena-compatible SPARQL query (used to get the results) to figure out namespaces. This PR is matched with https://github.com/bioclipse/bioclipse.core/pull/66 and allows code to use SPARQL end points without Jena.